### PR TITLE
fix: parsing spaced literal type annotations

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- [Spaces inside Literal type annotations breaks pycln by @hadialqattan [the raw idea by @zealotous]](https://github.com/hadialqattan/pycln/pull/45)
+
 ## [0.0.1-beta.1] - 2020-12-31
 
 ### Fixed

--- a/pycln/utils/scan.py
+++ b/pycln/utils/scan.py
@@ -214,7 +214,17 @@ class SourceAnalyzer(ast.NodeVisitor):
             else:
                 s_val = node.slice.value  # type: ignore
             for elt in getattr(s_val, "elts", ()) or (s_val,):
-                self._parse_string(elt)  # type: ignore
+                try:
+                    self._parse_string(elt)  # type: ignore
+                except UnparsableFile:
+                    #: Ignore errors when parsing Literal
+                    #: that are not valid identifiers.
+                    #:
+                    #: >>> from typing import Literal
+                    #: >>> L: Literal[" "] = " "
+                    #:
+                    #: Issue: https://github.com/hadialqattan/pycln/issues/41
+                    pass
 
     @recursive
     def visit_Try(self, node: ast.Try):

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -274,6 +274,16 @@ class TestSourceAnalyzer(AnalyzerTestCase):
                 {"x", "y"},
                 id="tuple-attr",
             ),
+            pytest.param(
+                (
+                    "from typing import Union\n"
+                    "import bar.y\n"
+                    "baz = Union['foo x', 'bar.y']\n"
+                ),
+                {"Union", "bar", "baz"},
+                {"y"},
+                id="literal with space (i41)",
+            ),
         ],
     )
     def test_visit_Subscript(self, code, expec_names, expec_attrs):


### PR DESCRIPTION
fix: #41 