### PR TITLE
Fix: Invalid PIP-526 type comments make Pycln crashes.

### DIFF
--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -16,5 +16,3 @@
 
 <!-- Please write your name alphabetically and use the below template. -->
 <!-- - First Last ([@username](https://github.com/username)) <example@email.com> -->
-
-- Matej Bašić ([@matejbasic](https://github.com/matejbasic)) <mbasic3310@gmail.com>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- [Invalid PIP-526 type comments make Pycln crashes with an UnparsableFile error by @hadialqattan](https://github.com/hadialqattan/pycln/pull/59)
+
 ## [0.0.3] - 2021-07-01
 
 ### Changed

--- a/pycln/utils/scan.py
+++ b/pycln/utils/scan.py
@@ -352,8 +352,17 @@ class SourceAnalyzer(ast.NodeVisitor):
                 mode = "eval"
             else:
                 mode = "func_type"
-            tree = parse_ast(type_comment, mode=mode)
-            self._add_name_attr(tree)
+            try:
+                tree = parse_ast(type_comment, mode=mode)
+                self._add_name_attr(tree)
+            except UnparsableFile:
+                #: Ignore errors when it's not a valid type comment.
+                #:
+                #: Sometimes we find nodes (comments)
+                #: satisfy PIP-526 type comment rules, but they're not valid.
+                #:
+                #: Issue: https://github.com/hadialqattan/pycln/issues/58
+                pass
 
     def _parse_string(self, node: Union[ast.Constant, ast.Str]) -> None:
         # Parse string names/attrs.

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -455,6 +455,11 @@ class TestSourceAnalyzer(AnalyzerTestCase):
                 id="async-function",
             ),
             pytest.param("foobar = 'x'\n", None, id="no type comment"),
+            pytest.param(
+                "foo = []  # type: optional, defaults to '[]'\n",
+                set({}),
+                id="non-valid",
+            ),
         ],
     )
     @mock.patch(MOCK % "SourceAnalyzer.visit_Name")


### PR DESCRIPTION
Fix: #58 