### PR TITLE
Add: support __all__ dunder overriding with concatenation.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- [Support `__all__` with add binary operator (concatenation) by @hadialqattan](https://github.com/hadialqattan/pycln/pull/64)
 - [Support `__all__` list operations (append & extend) by @hadialqattan](https://github.com/hadialqattan/pycln/pull/63)
 
 ## [0.0.4] - 2021-07-07

--- a/docs/README.md
+++ b/docs/README.md
@@ -867,8 +867,13 @@ __all__ = ["os", "time"]
 
 #### List Concatenation
 
-> Not supported yet, on the roadmap:
-> [# TODO](https://github.com/hadialqattan/pycln/projects/1#card-46607703)
+> Pycln can deal with list concatenation (`[...] + [...]`).
+
+```python
+import os, time  # These imports are considered as used.
+
+__all__ = ["os"] + ["time"]
+```
 
 #### List Comprehension
 

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -380,10 +380,16 @@ class TestSourceAnalyzer(AnalyzerTestCase):
                 id="names to skip",
             ),
             pytest.param(
-                "__all__ = ['x', 'y', 'z']\n",
+                "__all__ = ['x', 'y', 'z']",
                 {"x", "y", "z"},
                 {"__all__"},
                 id="__all__ dunder overriding",
+            ),
+            pytest.param(
+                "__all__ = ['x', 'y'] + ['i', 'j'] + ['z']",
+                {"x", "y", "i", "j", "z"},
+                {"__all__"},
+                id="__all__ dunder overriding - concatenation",
             ),
         ],
     )
@@ -638,7 +644,12 @@ class TestImportablesAnalyzer(AnalyzerTestCase):
                 ("x = 'y'\n" "__all__ = ['i', 'j', 'k']"),
                 {"i", "j", "k"},
                 id="__all__ dunder overriding",
-            )
+            ),
+            pytest.param(
+                "__all__ = ['x', 'y'] + ['i', 'j'] + ['z']",
+                {"x", "y", "i", "j", "z"},
+                id="__all__ dunder overriding - concatenation",
+            ),
         ],
     )
     def test_visit_Assign(self, code, expec_importables):


### PR DESCRIPTION
Fixes: #28 