### PR TITLE
Exit normally when no files were present to be cleaned

### DIFF
--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -16,3 +16,5 @@
 
 <!-- Please write your name alphabetically and use the below template. -->
 <!-- - First Last ([@username](https://github.com/username)) <example@email.com> -->
+
+- RooTer Urbański ([@rooterkyberian](https://github.com/rooterkyberian)) <rooter@kyberian.net>

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -17,4 +17,5 @@
 <!-- Please write your name alphabetically and use the below template. -->
 <!-- - First Last ([@username](https://github.com/username)) <example@email.com> -->
 
-- RooTer Urbański ([@rooterkyberian](https://github.com/rooterkyberian)) <rooter@kyberian.net>
+- RooTer Urbański ([@rooterkyberian](https://github.com/rooterkyberian))
+  <rooter@kyberian.net>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- [Exit normally (code 0) when no files were present to be cleaned by @rooterkyberian](https://github.com/hadialqattan/pycln/pull/84)
 - [Parsing local path import with null-pacakge causes AttributeError by @hadialqattan](https://github.com/hadialqattan/pycln/pull/76)
 - [RecursionError occurs when expanding a star import that has too many related modules by @hadialqattan](https://github.com/hadialqattan/pycln/pull/75)
 

--- a/pycln/utils/report.py
+++ b/pycln/utils/report.py
@@ -366,7 +366,7 @@ class Report:
                 + "No Python files are present to be cleaned. Nothing to do 😴",
                 bold=True,
             )
-            raise typer.Exit(1)
+            raise typer.Exit(0)
 
         if any([self.configs.check, self.configs.diff]):
             removed_imports = "would be removed"


### PR DESCRIPTION
Currently, with following configuration:
`pyproject.toml`:
```
[tool.pycln]
all = true
expand-stars = true
exclude= "(.eggs|.git|.mypy_cache|__pycache__|__init__.py)"
```
`.pre-commit-config.yaml`:
```
repos:
  - repo: https://github.com/hadialqattan/pycln
    rev: v1.0.3
    hooks:
      - id: pycln
        args: [--config=pyproject.toml]

```

when commiting only after editing `__init__.py` you get:
```
pycln....................................................................Failed
- hook id: pycln
- exit code: 1

No Python files are present to be cleaned. Nothing to do 😴
```