### PR TITLE
Preserving trailing comma style in multi-line imports.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- [Preserving trailing comma style in multi-line imports by @hadialqattan](https://github.com/hadialqattan/pycln/pull/86)
 - [Exit normally (code 0) when no files were present to be cleaned by @rooterkyberian](https://github.com/hadialqattan/pycln/pull/84)
 - [Parsing local path import with null-pacakge causes AttributeError by @hadialqattan](https://github.com/hadialqattan/pycln/pull/76)
 - [RecursionError occurs when expanding a star import that has too many related modules by @hadialqattan](https://github.com/hadialqattan/pycln/pull/75)

--- a/pycln/utils/transform.py
+++ b/pycln/utils/transform.py
@@ -10,9 +10,9 @@ from ._nodes import NodeLocation
 # Constants.
 SPACE4 = " " * 4
 
-# Custom types.
+# Custom types & annotations.
 ImportT = TypeVar("ImportT", bound=Union[cst.Import, cst.ImportFrom])
-TrailingCommaT = Union[cst.MaybeSentinel, cst.Comma]
+TrailingCommaA = Union[cst.MaybeSentinel, cst.Comma]
 
 
 class ImportTransformer(cst.CSTTransformer):
@@ -30,7 +30,7 @@ class ImportTransformer(cst.CSTTransformer):
         self._used_names = used_names
         self._location = location
         self._indentation = " " * location.start.col
-        self._trailing_comma: TrailingCommaT = cst.MaybeSentinel.DEFAULT
+        self._trailing_comma: TrailingCommaA = cst.MaybeSentinel.DEFAULT
 
     def refactor_import_star(self, updated_node: cst.ImportFrom) -> cst.ImportFrom:
         """Add used import aliases to import star.

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -173,7 +173,7 @@ class TestImportTransformer:
                 id="single, parentheses, no-end-comma, some-unused",
             ),
             pytest.param(
-                "from xxx import (x, y, z,)",
+                "from xxx import (x, y, z)",
                 1,
                 ("x", "y", "z"),
                 "from xxx import (x, y, z)",
@@ -183,7 +183,7 @@ class TestImportTransformer:
                 "from xxx import (x, y, z,)",
                 1,
                 ("x", "z"),
-                "from xxx import (x, z)",
+                "from xxx import (x, z,)",
                 id="single, parentheses, nend-comma, some-unused",
             ),
             pytest.param(
@@ -253,7 +253,7 @@ class TestImportTransformer:
                 ("from xxx import (\n" "    x,\n" "    y,\n" "    z,\n" ")"),
                 5,
                 ("x", "y", "z"),
-                ("from xxx import (\n" "    x,\n" "    y,\n" "    z\n" ")"),
+                ("from xxx import (\n" "    x,\n" "    y,\n" "    z,\n" ")"),
                 id="multi, parentheses, end-comma, no-unused",
             ),
             pytest.param(
@@ -267,7 +267,7 @@ class TestImportTransformer:
                 ("from xxx import (\n" "    x,\n" "    y,\n" "    z,\n" ")"),
                 5,
                 ("x", "z"),
-                ("from xxx import (\n" "    x,\n" "    z\n" ")"),
+                ("from xxx import (\n" "    x,\n" "    z,\n" ")"),
                 id="multi, parentheses, end-comma, some-unused",
             ),
             pytest.param(
@@ -281,7 +281,7 @@ class TestImportTransformer:
                 ("from xxx import (\n" "    x,\n" "    y, z,\n" ")"),
                 4,
                 ("x", "z"),
-                ("from xxx import (\n" "    x,\n" "    z\n" ")"),
+                ("from xxx import (\n" "    x,\n" "    z,\n" ")"),
                 id="multi, parentheses, double, end-comma, some-unused",
             ),
             pytest.param(
@@ -317,7 +317,7 @@ class TestImportTransformer:
                     "from xxx import (\n"
                     "    xx as x,\n"
                     "    yy as y,\n"
-                    "    zz as z\n"
+                    "    zz as z,\n"
                     ")"
                 ),
                 id="multi, parentheses, end-comma, no-unused, as",
@@ -345,7 +345,7 @@ class TestImportTransformer:
                 ),
                 5,
                 ("xx", "zz"),
-                ("from xxx import (\n" "    xx as x,\n" "    zz as z\n" ")"),
+                ("from xxx import (\n" "    xx as x,\n" "    zz as z,\n" ")"),
                 id="multi, parentheses, end-comma, some-unused, as",
             ),
             pytest.param(
@@ -359,7 +359,7 @@ class TestImportTransformer:
                 ("from xxx import (\n" "    xx as x,\n" "    yy as y, zz as z,\n" ")"),
                 4,
                 ("xx", "zz"),
-                ("from xxx import (\n" "    xx as x,\n" "    zz as z\n" ")"),
+                ("from xxx import (\n" "    xx as x,\n" "    zz as z,\n" ")"),
                 id="multi, parentheses, double, end-comma, some-unused, as",
             ),
         ],


### PR DESCRIPTION
Fix: #77 