### PR TITLE
Fix: Pycln removes extra lines.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,15 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- [Pycln removes extra lines in import-from multiline case (shown bellow) by @hadialqattan](https://github.com/hadialqattan/pycln/pull/87)
+
+  ```python3
+  from xxx import (i,
+      j,
+      k)
+  # if j isn't used, Pycln will remove this line no matter what it is!
+  ```
+
 - [Preserving trailing comma style in multi-line imports by @hadialqattan](https://github.com/hadialqattan/pycln/pull/86)
 - [Exit normally (code 0) when no files were present to be cleaned by @rooterkyberian](https://github.com/hadialqattan/pycln/pull/84)
 - [Parsing local path import with null-pacakge causes AttributeError by @hadialqattan](https://github.com/hadialqattan/pycln/pull/76)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -362,6 +362,13 @@ class TestImportTransformer:
                 ("from xxx import (\n" "    xx as x,\n" "    zz as z,\n" ")"),
                 id="multi, parentheses, double, end-comma, some-unused, as",
             ),
+            pytest.param(
+                ("from xxx import (x,\n" "    y,\n" "    z,)"),
+                3,
+                ("x", "z"),
+                ("from xxx import (x,\n" "    z,)"),
+                id="multi, parentheses(no-new-lines), end-comma, some-unused",
+            ),
         ],
     )
     def test_leave_ImportFrom(self, impt_stmnt, endlineno, used_names, expec_impt):


### PR DESCRIPTION
Fix: #79 

---
Demonstration case:
```python3
  from xxx import (i,
      j,
      k)
  # if j isn't used, Pycln will remove this line no matter what it is!
  ```