### PR TITLE
Fix: Pycln does not skip imports that have "nopycln/noqa" on the last line.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,10 +12,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- [Add support for Python 3.10](https://github.com/hadialqattan/pycln/pull/81)
+- [Add support for Python 3.10 by @hadialqattan](https://github.com/hadialqattan/pycln/pull/81)
 
 ### Fixed
 
+- [Pycln does not skip imports that have "# nopycln: import" or "# noqa" on the last line by @hadialqattan](https://github.com/hadialqattan/pycln/pull/88)
 - [Pycln removes extra lines in import-from multiline case (shown bellow) by @hadialqattan](https://github.com/hadialqattan/pycln/pull/87)
 
   ```python3

--- a/pycln/utils/refactor.py
+++ b/pycln/utils/refactor.py
@@ -200,8 +200,11 @@ class Refactor:
             for node in type_:
 
                 # Skip any import that has `# noqa` or `# nopycln: import` comment.
-                lineno = node.location.start.line - 1
-                if regexu.skip_import(fixed_lines[lineno]):
+                s_lineno = node.location.start.line - 1
+                e_lineno = node.location.end.line - 1
+                if regexu.skip_import(fixed_lines[s_lineno]) or regexu.skip_import(
+                    fixed_lines[e_lineno]
+                ):
                     self.reporter.ignored_import(self._path, node)
                     continue
 

--- a/pycln/utils/scan.py
+++ b/pycln/utils/scan.py
@@ -184,7 +184,7 @@ class SourceAnalyzer(ast.NodeVisitor):
         self._source_stats.attr_.add(node.attr)
 
     @recursive
-    def visit_MatchAs(self, node: 'ast.MatchAs'):
+    def visit_MatchAs(self, node: "ast.MatchAs"):  # type: ignore
         #: Support Match statement (PYTHON >= 3.10).
         #: PEP0634: https://www.python.org/dev/peps/pep-0634/
         self._source_stats.name_.add(node.name)


### PR DESCRIPTION
Fix: #80 