### PR TITLE
Fix: pycln removes imported names that should be exported

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- [Pycln removes imported names that should be exported in case of `__init__.py` file without `__all__` dunder by @hadialqattan](https://github.com/hadialqattan/pycln/pull/97)
 - [The path argument is ignored when passed in a config file by @hadialqattan](https://github.com/hadialqattan/pycln/pull/95)
 - [Remove star imports when nothing's actually imported by @pmourlanne](https://github.com/hadialqattan/pycln/pull/92)
 

--- a/pycln/utils/refactor.py
+++ b/pycln/utils/refactor.py
@@ -183,6 +183,11 @@ class Refactor:
             analyzer = scan.SourceAnalyzer(original_lines)
             analyzer.visit(tree)
             source_stats, import_stats = analyzer.get_stats()
+
+            if regexu.is_init_file(self._path) and not analyzer.has_all():
+                self.reporter.init_without_all_warning(self._path)
+                return None
+
             return source_stats, import_stats
         except Exception as err:
             self.reporter.failure(str(err), self._path)

--- a/pycln/utils/regexu.py
+++ b/pycln/utils/regexu.py
@@ -17,6 +17,7 @@ EXCLUDE = "exclude"
 GITIGNORE = ".gitignore"
 SKIP_FILE_REGEX = r"# *(nopycln *: *file).*"
 SKIP_IMPORT_REGEX = r"# *((noqa *:*)|(nopycln *: *import)).*"
+INIT_FILE_REGEX = r"^__init__.py$"
 INCLUDE_REGEX = r".*\.py$"
 EXCLUDE_REGEX = (
     r"(\.eggs|\.git|\.hg|\.mypy_cache|__pycache__|\.nox|"
@@ -56,6 +57,16 @@ def strpath(path: Path) -> str:
         return path_str if path.is_file() else f"{path_str}/"
     else:
         return f"{path}" if path.is_file() else f"{path}/"
+
+
+def is_init_file(path: Path) -> bool:
+    """Check if the file name is `__init__.py`.
+
+    :param path: file-system path to check.
+    :returns: True if the file is `__init__.py` else False.
+    """
+    regex: Pattern[str] = safe_compile(INIT_FILE_REGEX, INCLUDE)
+    return bool(regex.match(path.name))
 
 
 def is_included(path: Path, regex: Pattern[str]) -> bool:

--- a/tests/test_regexu.py
+++ b/tests/test_regexu.py
@@ -89,6 +89,29 @@ class TestRegexU:
         assert regexu.strpath(path) == expec_strpath
 
     @pytest.mark.parametrize(
+        "path, expec",
+        [
+            pytest.param(
+                Path("path/to/__init__.py"),
+                True,
+                id="exact - true",
+            ),
+            pytest.param(
+                Path("path/to/not__init__.py"),
+                False,
+                id="similar0 - false",
+            ),
+            pytest.param(
+                Path("path/to/init.py"),
+                False,
+                id="similar1 - false",
+            ),
+        ],
+    )
+    def test_is_init_file(self, path, expec):
+        assert regexu.is_init_file(path) == expec
+
+    @pytest.mark.parametrize(
         "path, regex, expec",
         [
             pytest.param(

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -248,6 +248,24 @@ class TestReport:
             assert self.reporter._failures == 1
 
     @pytest.mark.parametrize(
+        "mode, is_err",
+        [
+            ("default", True),
+            ("check", True),
+            ("diff", True),
+            ("verbose", True),
+            ("quiet", True),
+            ("silence", False),
+        ],
+    )
+    def test_init_without_all_warning(self, mode, is_err):
+        setattr(self.configs, mode, True)
+        with sysu.std_redirect(sysu.STD.ERR) as stderr:
+            self.reporter.init_without_all_warning(Path(""))
+            assert bool(stderr.getvalue()) == is_err
+            assert self.reporter._undecidable_case == 1
+
+    @pytest.mark.parametrize(
         "_failures, _changed_files, check, expec_code",
         [
             pytest.param(1, None, True, 250, id="internal error (check)"),
@@ -267,7 +285,7 @@ class TestReport:
         "counters, mode, output_mode, err, is_out, expec_in_out",
         [
             pytest.param(
-                (0, 0, 0, 0, 0, 0, 0),
+                (0, 0, 0, 0, 0, 0, 0, 0),
                 "not-matter",
                 "silence",
                 sysu.Pass,
@@ -276,7 +294,7 @@ class TestReport:
                 id="silence",
             ),
             pytest.param(
-                (0, 0, 0, 0, 0, 0, 0),
+                (0, 0, 0, 0, 0, 0, 0, 0),
                 "not-matter",
                 "not-matter",
                 Exit,
@@ -285,7 +303,7 @@ class TestReport:
                 id="no-file",
             ),
             pytest.param(
-                (1, 0, 1, 0, 0, 0, 0),
+                (1, 0, 1, 0, 0, 0, 0, 0),
                 "check",
                 "default",
                 sysu.Pass,
@@ -294,7 +312,7 @@ class TestReport:
                 id="check",
             ),
             pytest.param(
-                (1, 0, 1, 0, 0, 0, 0),
+                (1, 0, 1, 0, 0, 0, 0, 0),
                 "diff",
                 "default",
                 sysu.Pass,
@@ -303,7 +321,7 @@ class TestReport:
                 id="diff",
             ),
             pytest.param(
-                (1, 0, 1, 0, 0, 0, 0),
+                (1, 0, 1, 0, 0, 0, 0, 0),
                 "default",
                 "default",
                 sysu.Pass,
@@ -312,7 +330,7 @@ class TestReport:
                 id="default",
             ),
             pytest.param(
-                (1, 1, 1, 1, 0, 1, 1),
+                (1, 1, 1, 1, 0, 0, 1, 1),
                 "default",
                 "verbose",
                 sysu.Pass,
@@ -328,7 +346,7 @@ class TestReport:
                 id="verbose, ignored",
             ),
             pytest.param(
-                (2, 3, 4, 5, 0, 3, 2),
+                (2, 3, 4, 5, 0, 0, 3, 2),
                 "default",
                 "verbose",
                 sysu.Pass,
@@ -344,7 +362,7 @@ class TestReport:
                 id="verbose, ignored, plural",
             ),
             pytest.param(
-                (1, 1, 1, 1, 0, 0, 0),
+                (1, 1, 1, 1, 0, 0, 0, 0),
                 "default",
                 "default",
                 sysu.Pass,
@@ -353,22 +371,31 @@ class TestReport:
                 id="normal",
             ),
             pytest.param(
-                (0, 0, 0, 1, 0, 0, 0),
+                (0, 0, 0, 1, 0, 0, 0, 0),
                 "default",
                 "default",
                 sysu.Pass,
                 True,
                 "Looks good!",
-                id="failures",
+                id="no-changes",
             ),
             pytest.param(
-                (1, 1, 1, 1, 1, 1, 1),
+                (1, 1, 1, 1, 1, 1, 1, 1),
                 "default",
                 "default",
                 sysu.Pass,
                 True,
-                "Oh no, there is an error!",
-                id="failures-2",
+                "Oh no, there was an error!",
+                id="failure",
+            ),
+            pytest.param(
+                (1, 1, 1, 1, 0, 1, 1, 1),
+                "default",
+                "default",
+                sysu.Pass,
+                True,
+                "Wait a minute, there was an undecidable case!",
+                id="undecidable case",
             ),
         ],
     )
@@ -379,6 +406,7 @@ class TestReport:
             "_changed_files",
             "_unchanged_files",
             "_failures",
+            "_undecidable_case",
             "_ignored_imports",
             "_ignored_paths",
         )

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -775,6 +775,30 @@ class TestSourceAnalyzer(AnalyzerTestCase):
         end_lineno = analyzer._get_end_lineno(lineno, is_parentheses)
         assert end_lineno == expec_end_lineno
 
+    @pytest.mark.parametrize(
+        "code, expec",
+        [
+            pytest.param(
+                "__all__ = []\n",
+                True,
+                id="__all__ - assign",
+            ),
+            pytest.param(
+                "__all__ += []\n",
+                True,
+                id="__all__ - aug-assign",
+            ),
+            pytest.param(
+                "x = []\n",
+                False,
+                id="no __all__",
+            ),
+        ],
+    )
+    def test_has_all(self, code, expec):
+        analyzer = self._get_analyzer(code)
+        assert analyzer.has_all() == expec
+
 
 class TestImportablesAnalyzer(AnalyzerTestCase):
 


### PR DESCRIPTION
Fixes: #82 

For more info: [init file without \_\_all\_\_ dunder](https://hadialqattan.github.io/pycln/#/?id=init-file-__init__py).

Continuation: PR #98 