### PR TITLE
Fix: pycln crashes in case of from . import *

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- [Pycln crashes with `IndexError` or `AttributeError` in case of `from . import *` by @hadialqattan](https://github.com/hadialqattan/pycln/pull/103)
+
 - [Skip any file containing a form feed character instead of breaking the code by @hadialqattan](https://github.com/hadialqattan/pycln/pull/102)
 
 - [Consider any import statement that is inlined with `:` as an unsupported case instead of breaking the code by @hadialqattan](https://github.com/hadialqattan/pycln/pull/101)

--- a/pycln/utils/pathu.py
+++ b/pycln/utils/pathu.py
@@ -250,7 +250,7 @@ def get_local_import_from_path(
             fpath = os.path.join(
                 *dirparts[:i],
                 *packages[:-1] if level > 0 else "",
-                f"{packages[-1]}{PY_EXTENSION}",
+                f"{packages[-1] if packages else '__init__'}{PY_EXTENSION}",
             )
         if os.path.isfile(fpath):
             return Path(fpath)
@@ -289,14 +289,15 @@ def get_module_path(paths: Set[Path], module: str) -> Optional[Path]:
     :param module: module name.
     :returns: `module` path if exist else None.
     """
-    module = module.split(".")[0]
-    for path in paths:
-        name = str(path.parts[-1]).split(".")[0]
-        if name == module:
-            if str(path).endswith(PY_EXTENSION):
-                return path
-            else:
-                return Path(os.path.join(path, __INIT__))
+    if module is not None:
+        module = module.split(".")[0]
+        for path in paths:
+            name = str(path.parts[-1]).split(".")[0]
+            if name == module:
+                if str(path).endswith(PY_EXTENSION):
+                    return path
+                else:
+                    return Path(os.path.join(path, __INIT__))
     # Path not found.
     return None
 

--- a/tests/test_pathu.py
+++ b/tests/test_pathu.py
@@ -185,6 +185,13 @@ class TestPathu:
                 id="from ..package import *",
             ),
             pytest.param(
+                "*",
+                ".",
+                1,
+                Path("pycln/tests/__init__.py"),
+                id="from . import *",
+            ),
+            pytest.param(
                 "sysu",
                 "utils",
                 1,
@@ -238,6 +245,18 @@ class TestPathu:
                 "std",
                 None,
                 id="not exists",
+            ),
+            pytest.param(
+                [
+                    #: This represents this case:
+                    #:
+                    #: >>> from . import *
+                    #:
+                    #: while the file is not in a package.
+                ],
+                None,
+                None,
+                id="not exists - no module",
             ),
         ],
     )


### PR DESCRIPTION
Example:
```python3
from . import *
```

Output before the fix:
```console
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/ubuntu/projects/duplication/pycln/pycln/__main__.py", line 5, in <module>
    app(prog_name=__name__)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/typer/main.py", line 214, in __call__
    return get_command(self)(*args, **kwargs)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/typer/main.py", line 500, in wrapper
    return callback(**use_params)  # type: ignore
  File "/home/ubuntu/projects/duplication/pycln/pycln/cli.py", line 155, in main
    session_maker.session(source)
  File "/home/ubuntu/projects/duplication/pycln/pycln/utils/refactor.py", line 147, in session
    fixed_lines = self._code_session(content).splitlines(True)
  File "/home/ubuntu/projects/duplication/pycln/pycln/utils/refactor.py", line 178, in _code_session
    return self._refactor(original_lines)
  File "/home/ubuntu/projects/duplication/pycln/pycln/utils/refactor.py", line 253, in _refactor
    node, is_star = self._expand_import_star(node)
  File "/home/ubuntu/projects/duplication/pycln/pycln/utils/refactor.py", line 368, in _expand_import_star
    node = cast(ImportFrom, scan.expand_import_star(node, self._path))
  File "/home/ubuntu/projects/duplication/pycln/pycln/utils/scan.py", line 861, in expand_import_star
    mpath = pathu.get_import_from_path(path, "*", node.module, node.level)
  File "/home/ubuntu/projects/duplication/pycln/pycln/utils/pathu.py", line 342, in get_import_from_path
    mpath = get_local_import_from_path(path, module, package, level)
  File "/home/ubuntu/projects/duplication/pycln/pycln/utils/pathu.py", line 253, in get_local_import_from_path
    f"{packages[-1]}{PY_EXTENSION}",
IndexError: list index out of range
```