### PR TITLE
Fix: Pycln does not cleanup finally blocks' bodies from useless passes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- [Pycln does not cleanup `finally` block body from useless `pass` statements by @hadialqattan](https://github.com/hadialqattan/pycln/pull/114)
+
 - [Pycln unnecessarily skips `try..except` imports when standard import exception(s) exist(s) by @hadialqattan](https://github.com/hadialqattan/pycln/pull/113)
 
 ## [1.2.4] - 2022-02-27

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- [Pycln does not cleanup `finally` block body from useless `pass` statements by @hadialqattan](https://github.com/hadialqattan/pycln/pull/114)
+- [Pycln does not cleanup `finally` blocks' bodies from useless `pass` statements by @hadialqattan](https://github.com/hadialqattan/pycln/pull/114)
 
 - [Pycln unnecessarily skips `try..except` imports when standard import exception(s) exist(s) by @hadialqattan](https://github.com/hadialqattan/pycln/pull/113)
 

--- a/pycln/utils/refactor.py
+++ b/pycln/utils/refactor.py
@@ -123,6 +123,10 @@ class Refactor:
                     remove_from_children(parent, orelse, len(orelse), white_list)
                     white_list = set(orelse)
 
+                if hasattr(parent, "finalbody"):
+                    finalbody = getattr(parent, "finalbody")
+                    remove_from_children(parent, finalbody, len(finalbody), white_list)
+
                 children = ast.iter_child_nodes(parent)
                 remove_from_children(parent, children, body_len, white_list)
 

--- a/tests/test_refactor.py
+++ b/tests/test_refactor.py
@@ -194,6 +194,22 @@ class TestRefactor:
                 ],
                 id="orelse parent - no-else",
             ),
+            pytest.param(
+                [
+                    "try:\n",
+                    "   pass\n",
+                    "finally:\n",
+                    "   pass\n",
+                    "   pass\n",
+                ],
+                [
+                    "try:\n",
+                    "   pass\n",
+                    "finally:\n",
+                    "   pass\n",
+                ],
+                id="finalbody parent",
+            ),
         ],
     )
     def test_remove_useless_passes(self, source_lines, expec_lines):


### PR DESCRIPTION
Before the fix:
```python3
try:
    ...
except BlahBlah:
   ...
finally:
   import unused
   pass
```
`pycln` will leave double pass statements on the `finally` block body:
```python3
try:
    ...
except BlahBlah:
   ...
finally:
   pass
   pass
```

---
After the fix:
```python3
try:
    ...
except BlahBlah:
   ...
finally:
   pass
```