### PR TITLE
support typing.TypeVar str cases.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- [Support `typing.TypeVar` when types passed as `str` @hadialqattan](https://github.com/hadialqattan/pycln/pull/137)
+
 ## [1.3.2] - 2022-04-27
 
 ### Changed
@@ -111,7 +115,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - [Pycln does not skip imports that have "# nopycln: import" or "# noqa" on the last line by @hadialqattan](https://github.com/hadialqattan/pycln/pull/88)
-- [Pycln removes extra lines in import-from multiline case (shown bellow) by @hadialqattan](https://github.com/hadialqattan/pycln/pull/87)
+- [Pycln removes extra lines in import-from multiline case (shown below) by @hadialqattan](https://github.com/hadialqattan/pycln/pull/87)
 
   ```python3
   from xxx import (i,

--- a/docs/README.md
+++ b/docs/README.md
@@ -707,7 +707,7 @@ $ pycln --show-completion
 
 ## General
 
-> All bellow cases and more are considered as used.
+> All the cases below and more are considered as used.
 
 ### Single Line
 
@@ -813,7 +813,7 @@ def bar() -> Tuple[int, int]:
 
 > Pycln can understand string type hints.
 
-All bellow imports are considered as used:
+All the imports below are considered as used:
 
 - Fully string:
 
@@ -851,7 +851,7 @@ All bellow imports are considered as used:
 > [Python 3.8+ variable annotations](https://www.python.org/dev/peps/pep-0526/) into
 > account.
 
-All bellow imports are considered as used:
+All the imports below are considered as used:
 
 - Assign:
 
@@ -886,13 +886,27 @@ All bellow imports are considered as used:
 
 > Pycln can understand `typing.cast` case.
 
-All bellow imports are considered as used:
+All the imports below are considered as used:
 
 ```python
 from typing import cast
 import foo, bar
 
 baz = cast("foo", bar)  # or typing.cast("foo", bar)
+```
+
+#### TypeVar
+
+> Pycln can understand `typing.TypeVar` 'str' cases.
+
+All the imports below are considered as used:
+
+```python
+from typing import TypeVar
+import Foo, Bar, Baz
+
+T1 = TypeVar("T1", "Foo", "Bar")  # unbounded
+T2 = TypeVar("T2", bound="Baz")  # bounded
 ```
 
 ### All (`__all__`)
@@ -1072,7 +1086,7 @@ both the developers and QA tools.
 
 ## Specific
 
-> All bellow cases are unsupported and not in the
+> All the cases below are unsupported and not in the
 > [roadmap](https://github.com/hadialqattan/pycln/projects/3). Only certain import
 > statements are effected (not the entire file). Also, Pycln will not touch these cases
 > at all to avoid any code break.

--- a/pycln/utils/refactor.py
+++ b/pycln/utils/refactor.py
@@ -90,7 +90,7 @@ class Refactor:
             #: Remove any `ast.Pass` node
             #: that is both useless and not in the `wl` (white list).
             #:
-            #: The below case is not going to be touched:
+            #: The case below is not going to be touched:
             #:
             #: >>> (async) (def) (class) foo:
             #: >>>      """DOCString"""

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -335,6 +335,7 @@ class TestSourceAnalyzer(AnalyzerTestCase):
     @pytest.mark.parametrize(
         "code, expec_names, expec_attrs",
         [
+            # `typing.cast` cases.
             pytest.param(
                 (
                     "from typing import cast\n"
@@ -370,6 +371,37 @@ class TestSourceAnalyzer(AnalyzerTestCase):
                 {"cast", "foo", "bar", "baz"},
                 {"x"},
                 id="cast attr-1",
+            ),
+            # `typing.TypeVar` cases.
+            pytest.param(
+                (
+                    "from typing import TypeVar\n"
+                    "import Foo, Bar\n"
+                    "T_1 = TypeVar('T1', 'Foo', 'Bar')\n"
+                ),
+                {"TypeVar", "T_1", "Foo", "Bar"},
+                set(),
+                id="TypeVar unbounded",
+            ),
+            pytest.param(
+                (
+                    "import typing\n"
+                    "import Foo, Bar\n"
+                    "T_1 = typing.TypeVar('T1', 'Foo', 'Bar')\n"
+                ),
+                {"typing", "T_1", "Foo", "Bar"},
+                {"TypeVar"},
+                id="TypeVar[attr] unbounded",
+            ),
+            pytest.param(
+                (
+                    "from typing import TypeVar\n"
+                    "import Foo\n"
+                    "T_1 = TypeVar('T1', bound='Foo')\n"
+                ),
+                {"TypeVar", "T_1", "Foo"},
+                set(),
+                id="TypeVar bounded",
             ),
         ],
     )


### PR DESCRIPTION
All the imports below are considered as used:

```python
from typing import TypeVar
import Foo, Bar, Baz

T1 = TypeVar("T1", "Foo", "Bar")  # unbounded
T2 = TypeVar("T2", bound="Baz")  # bounded
```