### PR TITLE
Fix: `pass` statements are removed from `finallybody` parent nodes causing syntax errors.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- [`pass` statements are removed from `finallybody` parent nodes causing syntax errors by @hadialqattan](https://github.com/hadialqattan/pycln/pull/143)
+
 ## [1.3.3] - 2022-05-20
 
 ### Fixed

--- a/pycln/utils/refactor.py
+++ b/pycln/utils/refactor.py
@@ -125,6 +125,7 @@ class Refactor:
                 if hasattr(parent, "finalbody"):
                     finalbody = getattr(parent, "finalbody")
                     remove_from_children(parent, finalbody, len(finalbody), white_list)
+                    white_list = set(finalbody)
 
                 children = ast.iter_child_nodes(parent)
                 remove_from_children(parent, children, body_len, white_list)

--- a/tests/test_refactor.py
+++ b/tests/test_refactor.py
@@ -210,6 +210,23 @@ class TestRefactor:
                 ],
                 id="finalbody parent",
             ),
+            pytest.param(
+                ["try:\n", "   x = 1\n", "   y = 2\n", "finally:\n", "   pass\n"],
+                ["try:\n", "   x = 1\n", "   y = 2\n", "finally:\n", "   pass\n"],
+                id="finalbody parent - useful",
+            ),
+            pytest.param(
+                [
+                    "try:\n",
+                    "   x = 1\n",
+                    "   y = 2\n",
+                    "finally:\n",
+                    "   pass\n",
+                    "   pass\n",
+                ],
+                ["try:\n", "   x = 1\n", "   y = 2\n", "finally:\n", "   pass\n"],
+                id="finalbody parent - useless",
+            ),
         ],
     )
     def test_remove_useless_passes(self, source_lines, expec_lines):


### PR DESCRIPTION
Fix: #142 