### PR TITLE
Fix: treating non-dir paths as dirs crashing pycln.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- [in the modules' path finding functionality non-directory paths are treated as directories causing `Permission denied` errors crashing Pycln by @hadialqattan](https://github.com/hadialqattan/pycln/pull/145)
+
 - [useful `pass` statements are removed from `orelse` parent nodes when both `finallybody` and `orelse` exist causing syntax errors by @hadialqattan](https://github.com/hadialqattan/pycln/pull/144)
 
 ## [1.3.4] - 2022-06-22

--- a/pycln/utils/pathu.py
+++ b/pycln/utils/pathu.py
@@ -358,7 +358,7 @@ def get_module_path(
             if name == module:
                 if str(path).endswith(PY_EXTENSION):
                     return path
-                else:
+                if Path(path).is_dir():
                     return Path(path).joinpath(__INIT__)
             if name == package:
                 mpath = get_local_import_from_path(path, module, package, level)

--- a/tests/test_pathu.py
+++ b/tests/test_pathu.py
@@ -315,26 +315,26 @@ class TestPathu:
         [
             pytest.param(
                 [
-                    Path("pycln/pycln/utils/pathu.py"),
-                    Path("pycln/tests/utils/sysu.py"),
+                    Path("pycln/utils/pathu.py"),
+                    Path("tests/utils/sysu.py"),
                 ],
                 "sysu",
-                Path("pycln/tests/utils/sysu.py"),
+                Path("tests/utils/sysu.py"),
                 id="module",
             ),
             pytest.param(
                 [
-                    Path("pycln/pycln/utils/pathu.py"),
-                    Path("pycln/tests/utils"),
+                    Path("pycln/utils/pathu.py"),
+                    Path("tests/utils"),
                 ],
                 "utils.sysu",
-                Path("pycln/tests/utils/__init__.py"),
+                Path("tests/utils/__init__.py"),
                 id="package.module",
             ),
             pytest.param(
                 [
-                    Path("pycln/pycln/setup.py"),
-                    Path("pycln/tests/utils/temp.py"),
+                    Path("pycln/setup.py"),
+                    Path("tests/utils/temp.py"),
                 ],
                 "std",
                 None,
@@ -351,6 +351,12 @@ class TestPathu:
                 None,
                 None,
                 id="not exists - no module",
+            ),
+            pytest.param(
+                [Path("tests/data/lib-dynload/math.ver.so0")],
+                "math",
+                None,
+                id="non-py non-dir containing module name",
             ),
         ],
     )


### PR DESCRIPTION
Fixes: #136 