### PR TITLE
Fix: Fully, nested, and semi string type commnets get ignored.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- [Fully, nested, and semi string type commnets get ignored by @hadialqattan](https://github.com/hadialqattan/pycln/pull/156)
+
 - [Semi string third-party generic type annotations get ignored by @hadialqattan](https://github.com/hadialqattan/pycln/pull/155)
 
 ## [2.0.2] - 2022-07-13

--- a/pycln/utils/scan.py
+++ b/pycln/utils/scan.py
@@ -413,7 +413,7 @@ class SourceAnalyzer(ast.NodeVisitor):
                 mode = "func_type"
             try:
                 tree = parse_ast(type_comment, mode=mode)
-                self._add_name_attr_const(tree)
+                self._add_name_attr_const(tree, True)
             except UnparsableFile:
                 #: Ignore errors when it's not a valid type comment.
                 #:
@@ -472,7 +472,7 @@ class SourceAnalyzer(ast.NodeVisitor):
             elif isinstance(node, ast.Attribute):
                 self._source_stats.attr_.add(node.attr)
             elif is_str_annotation and isinstance(node, ast.Constant):
-                self._source_stats.name_.add(node.value)
+                self._parse_string(node, is_str_annotation)
 
     def _get_py38_import_node(self, node: ast.Import) -> _nodes.Import:
         # Convert any Python < 3.8 `ast.Import`

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -630,9 +630,20 @@ class TestSourceAnalyzer(AnalyzerTestCase):
     @pytest.mark.parametrize(
         "code, expec_names",
         [
-            pytest.param("foo = []  # type: List[str]\n", {"List", "str"}, id="assign"),
+            pytest.param("foo = []  # type: List[str]", {"List", "str"}, id="assign"),
             pytest.param(
-                ("def foo(\n" "bar  # type: List[str]\n" "):\n" "    pass\n"),
+                "foo = []  # type: 'List[str]'", {"List", "str"}, id="assign-[str]"
+            ),
+            pytest.param(
+                "foo = []  # type: \"List['str']\"",
+                {"List", "str"},
+                id="assign-[nested-str]",
+            ),
+            pytest.param(
+                "foo = []  # type: List['str']", {"List", "str"}, id="assign-[semi-str]"
+            ),
+            pytest.param(
+                ("def foo(\n" "bar  # type: List[str]\n" "):\n" "    pass"),
                 {"List", "str"},
                 id="arg",
             ),


### PR DESCRIPTION
Examples:

```python3
from typing import List
from ast import Import

foo = [Import(...)]  # type: List['Import']
bar = [Import(...)]  # type: "List['Import']"
baz = [Import(...)]  # type: "List[Import]"
```