### PR TITLE
fix line ending

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+[Preserve the original line break format by @maxbachmann & @hadialqattan](https://github.com/hadialqattan/pycln/pull/197)
+
 ### Changed
 
 - [Bump JRubics/poetry-publish from 1.16 to 1.17 by @dependabot[bot]](https://github.com/hadialqattan/pycln/pull/201)

--- a/pycln/utils/iou.py
+++ b/pycln/utils/iou.py
@@ -96,6 +96,6 @@ def safe_write(path: Path, fixed_lines: List[str], encoding: str, newline: str) 
     """
     if not os.access(path, os.W_OK):
         raise WritePermissionError(13, "Permission denied [WRITE]", path)
-    with open(path, mode="w", encoding=encoding) as destination:
+    with open(path, mode="w", encoding=encoding, newline=newline) as destination:
         for line in fixed_lines:
-            destination.write(line.replace(os.linesep, newline))
+            destination.write(line)

--- a/pycln/utils/iou.py
+++ b/pycln/utils/iou.py
@@ -101,6 +101,6 @@ def safe_write(path: Path, fixed_lines: List[str], encoding: str, newline: str) 
     if fixed_lines:
         fixed_lines_newline = CRLF if CRLF == fixed_lines[0][-2:] else LF
 
-    with open(path, mode="w", encoding=encoding) as destination:
+    with open(path, mode="w", encoding=encoding, newline="") as destination:
         for line in fixed_lines:
             destination.write(line.replace(fixed_lines_newline, newline))

--- a/pycln/utils/iou.py
+++ b/pycln/utils/iou.py
@@ -90,12 +90,17 @@ def safe_write(path: Path, fixed_lines: List[str], encoding: str, newline: str) 
     :param path: `.py` file path.
     :param encoding: file encoding.
     :param fixed_lines: fixed source code lines.
-    :param newline: original file's newline (CRFL | FL).
+    :param newline: output file's newline (CRFL | FL).
     :raises WritePermissionError: when `os.W_OK` in permissions
         and the source does not have write permission.
     """
     if not os.access(path, os.W_OK):
         raise WritePermissionError(13, "Permission denied [WRITE]", path)
+
+    fixed_lines_newline = newline
+    if fixed_lines:
+        fixed_lines_newline = CRLF if CRLF == fixed_lines[0][-2:] else LF
+
     with open(path, mode="w", encoding=encoding) as destination:
         for line in fixed_lines:
-            destination.write(line.replace(os.linesep, newline))
+            destination.write(line.replace(fixed_lines_newline, newline))

--- a/tests/test_iou.py
+++ b/tests/test_iou.py
@@ -165,8 +165,8 @@ class TestIOU:
         "fixed_lines, expec_code, expec_newline, expec_err, chmod",
         [
             pytest.param(
-                ["import time\n", "time.time()\n"],
-                "import time\ntime.time()\n",
+                ["import time\n", "\ttime.time()\n"],
+                "import time\n\ttime.time()\n",
                 iou.LF,
                 sysu.Pass,
                 0o0644,
@@ -183,13 +183,14 @@ class TestIOU:
                     ISWIN, reason="os.access doesn't support Windows."
                 ),
             ),
+            pytest.param([], "", os.linesep, sysu.Pass, 0o0644, id="empty file"),
             pytest.param(
                 ["import time\n", "time.time()\n"],
-                "import time\ntime.time()\n",
+                "import time\r\ntime.time()\r\n",
                 iou.CRLF,
                 sysu.Pass,
                 0o0644,
-                id="newline - CRLF",
+                id="LF ~> CRLF",
             ),
             pytest.param(
                 ["import time\r\n", "time.time()\r\n"],
@@ -197,7 +198,7 @@ class TestIOU:
                 iou.LF,
                 sysu.Pass,
                 0o0644,
-                id="newline - LF",
+                id="CRLF ~> LF",
             ),
         ],
     )
@@ -213,8 +214,6 @@ class TestIOU:
             with sysu.reopenable_temp_file("".join(fixed_lines)) as tmp_path:
                 set_mode(str(tmp_path), chmod)
                 iou.safe_write(tmp_path, fixed_lines, "utf-8", expec_newline)
-                with open(tmp_path) as tmp0:
-                    assert tmp0.read() == expec_code
-                with open(tmp_path, "rb") as tmp1:
-                    assert expec_newline.encode() in tmp1.readline()
+                with open(tmp_path, "rb") as tmp:
+                    assert tmp.read() == expec_code.encode()
             raise sysu.Pass()


### PR DESCRIPTION
by default on file writes the line ending is replaced by os.linesep, so our own line endings do not persist. This can be fixed by passing the appropriate line ending.

---
Fixes: #202 