### PR TITLE
Widen `libcst` version pin

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- [Widen `libcst` version pin by @AlexWaygood](https://github.com/hadialqattan/pycln/pull/209)
+
 ## [2.1.6] - 2023-07-19
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dataclasses = {version = "^0.7", python = "3.6"}
 pyyaml = ">=5.3.1,<7.0.0"
 pathspec = ">=0.9.0,<0.12.0"
 tomlkit = "^0.11.1"
-libcst = [{version = ">=0.3.10,<0.5.0", python = ">=3.7"}, {version = ">=0.3.10,<0.4.0", python = "<3.7"}]
+libcst = [{version = ">=0.3.10,<1.1.0", python = ">=3.7"}, {version = ">=0.3.10,<0.4.0", python = "<3.7"}]
 
 [tool.poetry.dev-dependencies]
 requests = "^2.24.0"


### PR DESCRIPTION
Hi, thanks again for pycln!

Would you consider widening the libcst version pin you have, as this PR proposes? At typeshed, we have both pycln and pytype as test dependencies, and both packages depend on libcst. Recent versions of pytype [depend on `libcst >= 1.0.1`](https://github.com/google/pytype/blob/37a62b5221014cc2c5087111b0a5902b00b4147c/setup.cfg#L36), which means we can't currently have the latest version of pytype installed in the same virtual environment as pycln. We could probably work around that, but this change I'm proposing would make our lives a lot easier, if you'd consider it!