### PR TITLE
Change: Pycln is no longer tightly pinning its dependencies

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- [Pycln is no longer tightly pinning its dependencies by @hadialqattan](https://github.com/hadialqattan/pycln/pull/213)
+
 ## [2.1.7] - 2023-07-27
 
 ### Fixed

--- a/poetry.lock
+++ b/poetry.lock
@@ -410,6 +410,14 @@ test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.
 
 [[package]]
 name = "typing-extensions"
+version = "4.1.1"
+description = "Backported and Experimental Type Hints for Python 3.6+"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "typing-extensions"
 version = "4.6.2"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
@@ -456,7 +464,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=4.6)", "pytest-black (
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.2, <4"
-content-hash = "43b5fe377ca51989d8bf597de3d35de69900e2711a27cd436e62d32097f2a6a6"
+content-hash = "eb4d168d044bf74500194527e3aa86f8af1cea306e7178d7b7854461c05cd10c"
 
 [metadata.files]
 atomicwrites = [
@@ -703,6 +711,8 @@ typer = [
     {file = "typer-0.9.0.tar.gz", hash = "sha256:50922fd79aea2f4751a8e0408ff10d2662bd0c8bbfa84755a699f3bada2978b2"},
 ]
 typing-extensions = [
+    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
+    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
     {file = "typing_extensions-4.6.2-py3-none-any.whl", hash = "sha256:3a8b36f13dd5fdc5d1b16fe317f5668545de77fa0b8e02006381fd49d731ab98"},
     {file = "typing_extensions-4.6.2.tar.gz", hash = "sha256:06006244c70ac8ee83fa8282cb188f697b8db25bc8b4df07be1873c43897060c"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -410,14 +410,6 @@ test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.
 
 [[package]]
 name = "typing-extensions"
-version = "4.1.1"
-description = "Backported and Experimental Type Hints for Python 3.6+"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[[package]]
-name = "typing-extensions"
 version = "4.6.2"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
@@ -464,7 +456,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=4.6)", "pytest-black (
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.2, <4"
-content-hash = "eb4d168d044bf74500194527e3aa86f8af1cea306e7178d7b7854461c05cd10c"
+content-hash = "43b5fe377ca51989d8bf597de3d35de69900e2711a27cd436e62d32097f2a6a6"
 
 [metadata.files]
 atomicwrites = [
@@ -711,8 +703,6 @@ typer = [
     {file = "typer-0.9.0.tar.gz", hash = "sha256:50922fd79aea2f4751a8e0408ff10d2662bd0c8bbfa84755a699f3bada2978b2"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
-    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
     {file = "typing_extensions-4.6.2-py3-none-any.whl", hash = "sha256:3a8b36f13dd5fdc5d1b16fe317f5668545de77fa0b8e02006381fd49d731ab98"},
     {file = "typing_extensions-4.6.2.tar.gz", hash = "sha256:06006244c70ac8ee83fa8282cb188f697b8db25bc8b4df07be1873c43897060c"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,12 +25,12 @@ pycln = "pycln.cli:app"
 
 [tool.poetry.dependencies]
 python = ">=3.6.2, <4"
-typer = ">=0.4.1,<0.10.0"
+typer = ">=0.4.1"
 dataclasses = {version = "^0.7", python = "3.6"}
-pyyaml = ">=5.3.1,<7.0.0"
-pathspec = ">=0.9.0,<0.12.0"
-tomlkit = "^0.11.1"
-libcst = [{version = ">=0.3.10,<1.1.0", python = ">=3.7"}, {version = ">=0.3.10,<0.4.0", python = "<3.7"}]
+pyyaml = ">=5.3.1"
+pathspec = ">=0.9.0"
+tomlkit = ">=0.11.1"
+libcst = [{version = ">=0.3.10", python = ">=3.7"}, {version = ">=0.3.10,<0.4.0", python = "<3.7"}]
 
 [tool.poetry.dev-dependencies]
 requests = "^2.24.0"


### PR DESCRIPTION
As tightly locking dependencies serves no major purpose (at least in our case) and caused problems to maintainers of other projects that use Pycln (e.g. in [python/typeshel](https://github.com/python/typeshed) alone this caused issues multiple times see: [python/typeshed#10243](https://github.com/python/typeshed/pull/10243) and [hadialqattan/pycln#209](https://github.com/hadialqattan/pycln/pull/209)), I decided to stop tightly locking the dependencies to make everyone's life easier and to prevent project maintainers from removing Pycln from their projects (as of [python/typeshed#10498](https://github.com/python/typeshed/pull/10498) unfortunately😞).


---
_Note: that change is going to be included in the next minor release v2.2.0 (today)._

_Update: release [v2.2.0](https://github.com/hadialqattan/pycln/releases/tag/v2.2.0) has been already released._