### PR TITLE
Make pycln run with Python 3.12 (#221)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -18,6 +18,7 @@
 <!-- - First Last ([@username](https://github.com/username)) <example@email.com> -->
 
 - Alex Waygood ([@AlexWaygood](https://github.com/AlexWaygood)) <Alex.Waygood@gmail.com>
+- Per Fagrell ([@perfa](https://github.com/perfa)) <per.fagrell@gmail.com>
 - Perchun Pak ([@PerchunPak](https://github.com/PerchunPak)) <perchunpak@gmail.com>
 - Pierre Mourlanne ([@pmourlanne](https://github.com/pmourlanne)) <pmourlanne@gmail.com>
 - RooTer Urbański ([@rooterkyberian](https://github.com/rooterkyberian))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## Added
+
+- [Add support for Python 3.12 by @perfa](https://github.com/hadialqattan/pycln/pull/224)
+
+## Changed
+
 - [Drop Python3.6 by @hadialqattan](https://github.com/hadialqattan/pycln/pull/225)
 
 ## [2.3.0] - 2023-10-14

--- a/pycln/utils/pathu.py
+++ b/pycln/utils/pathu.py
@@ -135,7 +135,6 @@ def get_standard_lib_paths() -> Set[Path]:
     paths: Set[Path] = set()
 
     for lib_path in PYTHON_STDLIB_PATHS:
-
         for path in os.listdir(lib_path):
             paths.add(Path(os.path.join(lib_path, path)))
 
@@ -143,7 +142,6 @@ def get_standard_lib_paths() -> Set[Path]:
         lib_dynload_path = os.path.join(lib_path, LIB_DYNLOAD)
 
         if os.path.isdir(lib_dynload_path):
-
             for path in os.listdir(lib_dynload_path):
                 paths.add(Path(os.path.join(lib_dynload_path, path)))
 
@@ -160,7 +158,6 @@ def get_standard_lib_names() -> Set[str]:
     paths: Set[Path] = get_standard_lib_paths()
 
     for path in paths:
-
         name = str(path.parts[-1])
 
         if name.startswith("_") or "-" in name:
@@ -194,7 +191,6 @@ def get_third_party_lib_paths() -> Tuple[Set[Path], Set[Path]]:
             packages_paths.add(path)
 
     for path in packages_paths:
-
         for name in os.listdir(path):
             if name.endswith(PTH_EXTENSION):
                 for pth_path in _site.addpackage(path, name):
@@ -220,7 +216,6 @@ def get_local_import_path(path: Path, module: str) -> Optional[Path]:
 
     # Test different levels.
     for i in [None] + list(range(-10, -0)):  # type: ignore
-
         # If it's a file.
         fpath = os.path.join(*dirnames[:i], *names[:-1], f"{names[-1]}{PY_EXTENSION}")
         if os.path.isfile(fpath):

--- a/pycln/utils/refactor.py
+++ b/pycln/utils/refactor.py
@@ -22,9 +22,11 @@ from .report import Report
 
 if sys.version_info >= (3, 12):
     from pathlib import Path
+
     _flavour = os.path
 else:
     from pathlib import Path, _posix_flavour, _windows_flavour  # type: ignore
+
     _flavour = _windows_flavour if ISWIN else _posix_flavour
 
 # Constants.
@@ -36,7 +38,9 @@ PYCLN_UTILS = "pycln.utils"
 
 class PyPath(Path):
     """Path subclass that has `is_stub` property."""
+
     _flavour = _flavour
+
     def __init__(self, *args) -> None:  # pylint: disable=unused-argument
         if sys.version_info >= (3, 12):
             super().__init__(*args)
@@ -57,6 +61,7 @@ class LazyLibCSTLoader:
     THIS CLASS DOES NOT INCLUDED ON THE TESTS SUITE. SO DON'T MODIFY IT
     FOR ANY REASON!
     """
+
     def __init__(self):
         self._module = None
 
@@ -134,7 +139,6 @@ class Refactor:
 
         tree = ast.parse("".join(source_lines))
         for parent in ast.walk(tree):
-
             body = getattr(parent, "body", None)
             if body and hasattr(body, "__len__"):
                 body_len = len(body)
@@ -278,9 +282,7 @@ class Refactor:
         """
         fixed_lines = original_lines.copy()
         for type_ in self._import_stats:
-
             for node in type_:
-
                 # Skip any import that has `# noqa` or `# nopycln: import` comment.
                 s_lineno = node.location.start.line - 1
                 e_lineno = node.location.end.line - 1
@@ -405,7 +407,6 @@ class Refactor:
         try:
             is_star = False
             if node.names[0].name == "*":
-
                 #: [for `.pyi` files] PEP 484 - Star Imports rule:
                 #:
                 #: >>> from X import *  # exported (should be treated as used)

--- a/pycln/utils/refactor.py
+++ b/pycln/utils/refactor.py
@@ -20,14 +20,14 @@ from ._nodes import Import, ImportFrom, NodeLocation
 from .config import Config
 from .report import Report
 
-if sys.version_info >= (3, 12):
-    from pathlib import Path
-
-    _flavour = os.path
-else:
+if sys.version_info < (3, 12):
     from pathlib import Path, _posix_flavour, _windows_flavour  # type: ignore
 
     _flavour = _windows_flavour if ISWIN else _posix_flavour
+else:
+    from pathlib import Path
+
+    _flavour = os.path
 
 # Constants.
 NOPYCLN = "nopycln"
@@ -42,10 +42,10 @@ class PyPath(Path):
     _flavour = _flavour
 
     def __init__(self, *args) -> None:  # pylint: disable=unused-argument
-        if sys.version_info >= (3, 12):
-            super().__init__(*args)
-        else:
+        if sys.version_info < (3, 12):
             super().__init__()  # Path.__init__ does not take any args.
+        else:
+            super().__init__(*args)
         self._is_stub = regexu.is_stub_file(self)
 
     @property

--- a/pycln/utils/refactor.py
+++ b/pycln/utils/refactor.py
@@ -1,8 +1,8 @@
 """Pycln code refactoring utility."""
 import ast
 import os
+import sys
 from importlib import import_module
-from pathlib import Path, _posix_flavour, _windows_flavour  # type: ignore
 from typing import Iterable, List, Optional, Set, Tuple, Union, cast
 
 from .. import ISWIN
@@ -20,6 +20,13 @@ from ._nodes import Import, ImportFrom, NodeLocation
 from .config import Config
 from .report import Report
 
+if sys.version_info >= (3, 12):
+    from pathlib import Path
+    _flavour = os.path
+else:
+    from pathlib import Path, _posix_flavour, _windows_flavour  # type: ignore
+    _flavour = _windows_flavour if ISWIN else _posix_flavour
+
 # Constants.
 NOPYCLN = "nopycln"
 CHANGE_MARK = "\n_CHANGED_"
@@ -28,13 +35,13 @@ PYCLN_UTILS = "pycln.utils"
 
 
 class PyPath(Path):
-
     """Path subclass that has `is_stub` property."""
-
-    _flavour = _windows_flavour if ISWIN else _posix_flavour
-
+    _flavour = _flavour
     def __init__(self, *args) -> None:  # pylint: disable=unused-argument
-        super().__init__()  # Path.__init__ does not take any args.
+        if sys.version_info >= (3, 12):
+            super().__init__(*args)
+        else:
+            super().__init__()  # Path.__init__ does not take any args.
         self._is_stub = regexu.is_stub_file(self)
 
     @property
@@ -50,7 +57,6 @@ class LazyLibCSTLoader:
     THIS CLASS DOES NOT INCLUDED ON THE TESTS SUITE. SO DON'T MODIFY IT
     FOR ANY REASON!
     """
-
     def __init__(self):
         self._module = None
 

--- a/pycln/utils/scan.py
+++ b/pycln/utils/scan.py
@@ -751,7 +751,6 @@ class ImportablesAnalyzer(ast.NodeVisitor):
     def _compute_not_importables(self, node: Union[FunctionDefT, ast.ClassDef]):
         # Compute class/function not-importables.
         for node_ in ast.iter_child_nodes(node):
-
             if isinstance(node_, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
                 self._not_importables.add(cast(str, node_.name))
 
@@ -857,7 +856,6 @@ class SideEffectsAnalyzer(ast.NodeVisitor):
     def _check_names(names: List[ast.alias]) -> HasSideEffects:
         # Check if imported names has side effects or not.
         for alias in names:
-
             # All standard lib modules doesn't has side effects
             # except `pathu.IMPORTS_WITH_SIDE_EFFECTS`.
             if alias.name in pathu.get_standard_lib_names():

--- a/tests/test_pathu.py
+++ b/tests/test_pathu.py
@@ -387,8 +387,8 @@ class TestPathu:
                 id="import file : local",
             ),
             pytest.param(
-                "distutils",
-                Path("distutils/__init__.py"),
+                "asyncio",
+                Path("asyncio/__init__.py"),
                 id="import module : standard",
             ),
             pytest.param(
@@ -453,9 +453,9 @@ class TestPathu:
             ),
             pytest.param(
                 "*",
-                "distutils",
+                "asyncio",
                 0,
-                Path("distutils/__init__.py"),
+                Path("asyncio/__init__.py"),
                 id="from package import * : standard",
             ),
             pytest.param(


### PR DESCRIPTION
Changes were made to pathlib with the release of 3.12 the details of which can be [read here](https://discuss.python.org/t/make-pathlib-extensible/3428/133). Updated the code to reflect that you no longer need to directly refer to _posix_flaour nor _windows_flavour when inheriting from Path. The `__init__` function of Path does take args now. Finally, references to `disututils` were changed to `asyncio` (available from 3.4) as the `distutils` module has been removed in Python 3.12 breaking some tests.

Tests pass and pycln successfully run on local codebase with Python 3.12.0 and 3.10.13.

Fixes: #223, #221, #219