### PR TITLE
Use importlib.metadata instead of reading pyproject.toml in init

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry
-          python -m poetry install --no-root --with=dev
+          python -m poetry install --with=dev
 
       - name: Test with pytest by poetry
         run: |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- [Reading `pyproject.toml` causes missing `pyproject.toml` error by @or150](https://github.com/hadialqattan/pycln/pull/250)
+
 ## Changed
 
 - [Drop Python3.7 by @hadialqattan](https://github.com/hadialqattan/pycln)

--- a/pycln/__init__.py
+++ b/pycln/__init__.py
@@ -1,11 +1,11 @@
 import io
 import os
 import sys
-import tokenize
+from importlib.metadata import metadata
 from pathlib import Path
 
-import tomlkit
 import typer
+
 
 #: Add vendor directory to module search path
 VENDOR_PATH = Path(__file__).parent.parent.joinpath("vendor")
@@ -22,12 +22,10 @@ if "pytest" not in sys.modules:
 ISWIN = os.name == "nt"
 PYPROJECT_PATH = Path(__file__).parent.parent.joinpath("pyproject.toml")
 
-with tokenize.open(PYPROJECT_PATH) as toml_f:
-    pycln = tomlkit.parse(toml_f.read())["tool"]["poetry"]
-
-__name__ = str(pycln["name"])
-__doc__ = str(pycln["description"])
-__version__ = pycln["version"]
+pycln = metadata("pycln")
+__name__ = str(pycln["Name"])
+__doc__ = str(pycln["Summary"])
+__version__ = str(pycln["Version"])
 
 
 def version_callback(value: bool):

--- a/pycln/__init__.py
+++ b/pycln/__init__.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import typer
 
-
 #: Add vendor directory to module search path
 VENDOR_PATH = Path(__file__).parent.parent.joinpath("vendor")
 sys.path.append(str(VENDOR_PATH))

--- a/pycln/__init__.py
+++ b/pycln/__init__.py
@@ -19,7 +19,6 @@ if "pytest" not in sys.modules:
     sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding=UTF8)  # pragma: nocover
 
 ISWIN = os.name == "nt"
-PYPROJECT_PATH = Path(__file__).parent.parent.joinpath("pyproject.toml")
 
 pycln = metadata("pycln")
 __name__ = str(pycln["Name"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Topic :: Utilities"]
 license = "MIT"
 readme = "README.md"
-include = ["pyproject.toml"]
 packages = [{ include = "pycln" }, { include = "vendor" }]
 
 [tool.poetry.scripts]

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -4,6 +4,7 @@
 import sys
 import tokenize
 from os import getenv
+from pathlib import Path
 
 import pytest
 import requests
@@ -11,20 +12,14 @@ import tomlkit
 from semver import VersionInfo
 from typer import Exit
 
-from pycln import (
-    PYPROJECT_PATH,
-    VENDOR_PATH,
-    __doc__,
-    __name__,
-    __version__,
-    version_callback,
-)
+from pycln import VENDOR_PATH, __doc__, __name__, __version__, version_callback
 
 from .utils import sysu
 
 # Constants.
+PYPROJECT_PATH = Path(__file__).parent.parent.joinpath("pyproject.toml")
 with tokenize.open(PYPROJECT_PATH) as toml_f:
-    PYCLN_METADATA = tomlkit.parse(toml_f.read())["tool"]["poetry"]
+    PYCLN_METADATA = tomlkit.parse(toml_f.read())["tool"]["poetry"]  # type: ignore
 
 PYCLN_PYPI_JSON_URL = f"https://pypi.org/pypi/{__name__}/json"
 PYCLN_PYPI_URL = f"https://pypi.org/project/{__name__}/"


### PR DESCRIPTION
Hi,
This change makes pre-commit usages work again and fixes issues #249, #228.

The root cause for the issue is poetry-core just released a version 2.0 that doesn't add the `pyproject.toml` file to the root of `site-packages`, which I guess it wasn't there on purpose.  

It uses `importlib.metadata` instead of reading `pyproject.toml`, which should be compatible with both versions of poetry-core.

Thought about also changing build-system to:
```
[build-system]
requires = ["poetry-core>=1.0.0,<3.0.0"]
```
WDYT?