### PR TITLE
Refine AST node handling in string parsing functions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- [Use `ast.Constant` for `str` node handling since `ast.Str` was deprecated in Python 3.8 by @chrimaho](https://github.com/hadialqattan/pycln/pull/277)
+
 ## [2.5.0] - 2025-01-06
 
 ### Fixed

--- a/pycln/utils/scan.py
+++ b/pycln/utils/scan.py
@@ -463,12 +463,12 @@ class SourceAnalyzer(ast.NodeVisitor):
                 pass
 
     def _parse_string(
-        self, node: Union[ast.Constant, ast.Str], is_str_annotation: bool = False
+        self, node: ast.Constant, is_str_annotation: bool = False
     ) -> None:
         try:
             # Parse string names/attrs.
-            if isinstance(node, (ast.Constant, ast.Str)):
-                val = getattr(node, "value", "") or getattr(node, "s", "")
+            if isinstance(node, ast.Constant):
+                val = getattr(node, "value", "")
                 if val and isinstance(val, str):
                     val = val.strip()
                     tree = parse_ast(val, mode="eval")
@@ -496,9 +496,8 @@ class SourceAnalyzer(ast.NodeVisitor):
     def _add_list_names(self, node: List[ast.expr]) -> None:
         # Safely add list `const/str` names to `self._source_stats.name_`.
         for item in node:
-            if isinstance(item, (ast.Constant, ast.Str)):
-                key = "s" if hasattr(item, "s") else "value"
-                value = getattr(item, key, "")
+            if isinstance(item, ast.Constant):
+                value = getattr(item, "value", "")
                 if value and isinstance(value, str):
                     self._source_stats.name_.add(value)
 
@@ -740,9 +739,8 @@ class ImportablesAnalyzer(ast.NodeVisitor):
     def _add_list_names(self, node: List[ast.expr]) -> None:
         # Safely add list `const/str` names to `self._importables`.
         for item in node:
-            if isinstance(item, (ast.Constant, ast.Str)):
-                key = "s" if hasattr(item, "s") else "value"
-                value = getattr(item, key, "")
+            if isinstance(item, ast.Constant):
+                value = getattr(item, "value", "")
                 if value and isinstance(value, str):
                     self._importables.add(value)
 


### PR DESCRIPTION
This pull request refactors the handling of string nodes in the `pycln/utils/scan.py` file to rely exclusively on the `ast.Constant` type, removing support for the deprecated `ast.Str`. The changes simplify the logic for extracting string values from AST nodes and ensure compatibility with newer versions of Python.

AST node handling simplification:

* Updated the `_parse_string` method to only check for `ast.Constant` nodes and retrieve their string value using the `value` attribute, removing checks for `ast.Str` and the `s` attribute.

* Refactored both `_add_list_names` methods to only process `ast.Constant` nodes and extract their string value using the `value` attribute, eliminating logic for handling `ast.Str` nodes and the `s` attribute. [[1]](diffhunk://#diff-033b4b08790dea7d67163846f405eaf1b7cabfee03ed60b69a0d83182289f9e2L499-R500) [[2]](diffhunk://#diff-033b4b08790dea7d67163846f405eaf1b7cabfee03ed60b69a0d83182289f9e2L743-R743)

- Standardise checks to use only `ast.Constant` for string nodes, removing mixed handling of `ast.Str`
- Simplify and clarify value extraction logic by consistently accessing the `value` attribute
- Improve code maintainability and reduce ambiguity in parsing logic for list and string nodes

Closes #276